### PR TITLE
Added model for Score Strategy

### DIFF
--- a/Query/Query.php
+++ b/Query/Query.php
@@ -148,6 +148,13 @@ class Query implements HttpTransportable
     private $filterFields = [];
 
     /**
+     * @var ScoreStrategy
+     *
+     * Score strategy
+     */
+    private $scoreStrategy;
+
+    /**
      * @var User
      *
      * User associated to query
@@ -1125,6 +1132,30 @@ class Query implements HttpTransportable
     }
 
     /**
+     * Get score strategy.
+     *
+     * @return ScoreStrategy|null
+     */
+    public function getScoreStrategy(): ? ScoreStrategy
+    {
+        return $this->scoreStrategy;
+    }
+
+    /**
+     * Set score strategy.
+     *
+     * @param ScoreStrategy $scoreStrategy
+     *
+     * @return Query
+     */
+    public function setScoreStrategy(ScoreStrategy $scoreStrategy)
+    {
+        $this->scoreStrategy = $scoreStrategy;
+
+        return $this;
+    }
+
+    /**
      * Query by user.
      *
      * @param User $user
@@ -1205,6 +1236,9 @@ class Query implements HttpTransportable
                 ? null
                 : false,
             'filter_fields' => $this->filterFields,
+            'score_strategy' => $this->scoreStrategy instanceof ScoreStrategy
+                ? $this->scoreStrategy->toArray()
+                : null,
             'user' => ($this->user instanceof User)
                 ? $this->user->toArray()
                 : null,
@@ -1268,6 +1302,10 @@ class Query implements HttpTransportable
             return ItemUUID::createFromArray($itemUUID);
         }, $array['items_promoted'] ?? []);
         $query->filterFields = $array['filter_fields'] ?? [];
+        $query->scoreStrategy = isset($array['score_strategy'])
+            ? ScoreStrategy::createFromArray($array['score_strategy'])
+            : null;
+
         if (isset($array['user'])) {
             $query->user = User::createFromArray($array['user']);
         }

--- a/Query/ScoreStrategy.php
+++ b/Query/ScoreStrategy.php
@@ -1,0 +1,151 @@
+<?php
+
+/*
+ * This file is part of the Apisearch PHP Client.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author PuntMig Technologies
+ */
+
+declare(strict_types=1);
+
+namespace Apisearch\Query;
+
+use Apisearch\Exception\InvalidFormatException;
+use Apisearch\Model\HttpTransportable;
+
+/**
+ * Class ScoreStrategy.
+ */
+class ScoreStrategy implements HttpTransportable
+{
+    /**
+     * @var int
+     *
+     * Default score strategy
+     */
+    const DEFAULT = 0;
+
+    /**
+     * @var int
+     *
+     * Boosting by relevance field
+     */
+    const BOOSTING_RELEVANCE_FIELD = 1;
+
+    /**
+     * @var int
+     *
+     * Boosting by relevance field
+     */
+    const CUSTOM_FUNCTION = 2;
+
+    /**
+     * @var int
+     *
+     * Scoring type
+     */
+    private $type = self::DEFAULT;
+
+    /**
+     * @var null|string
+     *
+     * Scoring function
+     */
+    private $function = null;
+
+    /**
+     * Get type.
+     *
+     * @return int
+     */
+    public function getType(): int
+    {
+        return $this->type;
+    }
+
+    /**
+     * Get function.
+     *
+     * @return null|string
+     */
+    public function getFunction(): ? string
+    {
+        return $this->function;
+    }
+
+    /**
+     * Create empty.
+     *
+     * @return self
+     */
+    public static function createDefault(): self
+    {
+        return new self();
+    }
+
+    /**
+     * Create default relevance scoring.
+     *
+     * @return self
+     */
+    public static function createRelevanceBoosting(): self
+    {
+        $score = self::createDefault();
+        $score->type = self::BOOSTING_RELEVANCE_FIELD;
+
+        return $score;
+    }
+
+    /**
+     * Create custom function scoring.
+     *
+     * @param string $function
+     *
+     * @return self
+     */
+    public static function createCustomFunction(string $function): self
+    {
+        $score = self::createDefault();
+        $score->type = self::CUSTOM_FUNCTION;
+        $score->function = $function;
+
+        return $score;
+    }
+
+    /**
+     * To array.
+     *
+     * @return array
+     */
+    public function toArray(): array
+    {
+        return [
+            'type' => $this->type,
+            'function' => $this->function,
+        ];
+    }
+
+    /**
+     * Create from array.
+     *
+     * @param array $array
+     *
+     * @return self
+     *
+     * @throws InvalidFormatException
+     */
+    public static function createFromArray(array $array)
+    {
+        $score = new self();
+        $score->type = $array['type'] ?: self::DEFAULT;
+        $score->function = $array['function'] ?: null;
+
+        return $score;
+    }
+}

--- a/Tests/Query/QueryTest.php
+++ b/Tests/Query/QueryTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Apisearch\Tests\Query;
 
 use Apisearch\Query\Query;
+use Apisearch\Query\ScoreStrategy;
 use Apisearch\Query\SortBy;
 use PHPUnit_Framework_TestCase;
 
@@ -36,6 +37,7 @@ class QueryTest extends PHPUnit_Framework_TestCase
         $this->assertFalse(array_key_exists('aggregations', $queryArray));
         $this->assertFalse(array_key_exists('filter_fields', $queryArray));
         $this->assertFalse(array_key_exists('user', $queryArray));
+        $this->assertFalse(array_key_exists('score_strategy', $queryArray));
     }
 
     /**
@@ -68,5 +70,38 @@ class QueryTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(Query::DEFAULT_SIZE, $query->getSize());
         $this->assertEquals(SortBy::SCORE, $query->getSortBy());
         $this->assertNull($query->getUser());
+        $this->assertNull($query->getScoreStrategy());
+    }
+
+    /**
+     * Test score strategy object.
+     */
+    public function testScoreStrategyObject()
+    {
+        $function = 'xxx';
+        $scoreStrategy = ScoreStrategy::createCustomFunction($function);
+        $query = Query::createMatchAll()->setScoreStrategy($scoreStrategy);
+
+        $this->assertInstanceOf(
+            ScoreStrategy::class,
+            $query->getScoreStrategy()
+        );
+
+        $query = Query::createFromArray($query->toArray());
+
+        $scoreStrategy = $query->getScoreStrategy();
+        $this->assertInstanceOf(
+            ScoreStrategy::class,
+            $scoreStrategy
+        );
+
+        $this->assertEquals(
+            ScoreStrategy::CUSTOM_FUNCTION,
+            $scoreStrategy->getType()
+        );
+        $this->assertEquals(
+            $function,
+            $scoreStrategy->getFunction()
+        );
     }
 }

--- a/Tests/Query/ScoreStrategyTest.php
+++ b/Tests/Query/ScoreStrategyTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the Apisearch PHP Client.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author PuntMig Technologies
+ */
+
+declare(strict_types=1);
+
+namespace Apisearch\Tests\Query;
+
+use Apisearch\Query\ScoreStrategy;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * Class ScoreStrategyTest.
+ */
+class ScoreStrategyTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Test create default.
+     */
+    public function testCreateDefault()
+    {
+        $scoreStrategy = ScoreStrategy::createDefault();
+        $this->assertEquals(
+            ScoreStrategy::DEFAULT,
+            $scoreStrategy->getType()
+        );
+        $this->assertNull($scoreStrategy->getFunction());
+    }
+
+    /**
+     * Test create relevance boosting.
+     */
+    public function testCreateRelevanceBoosting()
+    {
+        $scoreStrategy = ScoreStrategy::createRelevanceBoosting();
+        $this->assertEquals(
+            ScoreStrategy::BOOSTING_RELEVANCE_FIELD,
+            $scoreStrategy->getType()
+        );
+        $this->assertNull($scoreStrategy->getFunction());
+    }
+
+    /**
+     * Test create default.
+     */
+    public function testCreateCustomFunction()
+    {
+        $function = 'xxx';
+        $scoreStrategy = ScoreStrategy::createCustomFunction($function);
+        $this->assertEquals(
+            ScoreStrategy::CUSTOM_FUNCTION,
+            $scoreStrategy->getType()
+        );
+        $this->assertEquals(
+            $function,
+            $scoreStrategy->getFunction()
+        );
+    }
+
+    /**
+     * Test http transportable methods.
+     */
+    public function testHttpTransportableMethods()
+    {
+        $function = 'xxx';
+        $array = [
+            'type' => ScoreStrategy::CUSTOM_FUNCTION,
+            'function' => $function,
+        ];
+        $scoreStrategy = ScoreStrategy::createFromArray($array);
+        $this->assertEquals(
+            ScoreStrategy::CUSTOM_FUNCTION,
+            $scoreStrategy->getType()
+        );
+        $this->assertEquals(
+            $function,
+            $scoreStrategy->getFunction()
+        );
+        $this->assertEquals(
+            $array,
+            $scoreStrategy->toArray()
+        );
+    }
+}


### PR DESCRIPTION
- Solves part of https://github.com/apisearch-io/search-server/issues/28
- Three initial strategies
    - Default - Default score
    - Relevance field - Checks indexed_metadata.relevance field value in order to change default calc
    - Custom function - Make your custom function (Painless Script)