### PR TITLE
TransformableRepository::getIndices() method should return array instead of void

### DIFF
--- a/Repository/TransformableRepository.php
+++ b/Repository/TransformableRepository.php
@@ -173,7 +173,7 @@ class TransformableRepository extends Repository
      */
     public function getIndices(string $appId = null): array
     {
-        $this
+        return $this
             ->repository
             ->getIndices($appId);
     }


### PR DESCRIPTION
Fix for #46 